### PR TITLE
Global event listener bug fix.

### DIFF
--- a/src/Manager/EventManager.php
+++ b/src/Manager/EventManager.php
@@ -299,6 +299,11 @@ class EventManager implements EventManagerInterface
             $shouldCall[$name] = '';
         }
 
+        // Have global wildcards '*' listener.
+        if (isset($this->listenedEvents['*'])) {
+            $shouldCall['*'] = '';
+        }
+
         // Like 'app.db.query' => prefix: 'app.db'
         if ($pos = strrpos($name, '.')) {
             $prefix = substr($name, 0, $pos);
@@ -335,12 +340,7 @@ class EventManager implements EventManagerInterface
             }
         }
 
-        // Have global wildcards '*' listener.
-        if (isset($this->listenedEvents['*'])) {
-            $this->triggerListeners($this->listeners['*'], $event);
-        }
-
-        return $this->destroyAfterFire ? $event->destroy() : $event;
+        return $event;
     }
 
     /**


### PR DESCRIPTION
Listener registered for `*` not catched `swoft.http.server.request.before`, `swoft.http.server.request.after` etc., due to code returned when `$shouldCall` is empty.

Please merge this fix into the master branch.

Thanks.